### PR TITLE
feat: GitHub Actionsによる自動リリースCI追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+  workflow_dispatch:
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      should-publish: ${{ steps.check.outputs.should_publish }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      
+      - name: Check if version changed
+        id: check
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "Current version: $CURRENT_VERSION"
+          
+          # Check if this version tag already exists
+          if git ls-remote --tags origin | grep -q "refs/tags/v${CURRENT_VERSION}$"; then
+            echo "Version v${CURRENT_VERSION} already published"
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "New version detected: v${CURRENT_VERSION}"
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+            echo "version=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+          fi
+
+  publish:
+    needs: check-version
+    if: needs.check-version.outputs.should-publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build
+        run: npm run build
+      
+      - name: Run tests
+        run: |
+          # Test that the CLI works
+          npm link
+          ccstats --version
+          ccstats --help
+      
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ needs.check-version.outputs.version }}
+          release_name: Release v${{ needs.check-version.outputs.version }}
+          body: |
+            ## 🚀 Released version ${{ needs.check-version.outputs.version }}
+            
+            This release was automatically published to npm.
+            
+            ### Installation
+            ```bash
+            npm install -g ccstats@${{ needs.check-version.outputs.version }}
+            ```
+            
+            ### Usage
+            ```bash
+            npx ccstats@${{ needs.check-version.outputs.version }}
+            ```
+            
+            See [npm package](https://www.npmjs.com/package/ccstats/v/${{ needs.check-version.outputs.version }}) for more details.
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -146,6 +146,32 @@ Add to your Claude Code settings.json:
 3. **Quick Stats**: Use custom commands like `/stats` for on-demand statistics
 4. **Performance Analysis**: Export to YAML/JSON for further analysis
 
+## Development
+
+### Release Process
+
+This repository uses GitHub Actions for automated releases. When the version in `package.json` is updated and pushed to the main branch, the release workflow automatically:
+
+1. Checks if the version is new
+2. Runs tests
+3. Publishes to npm
+4. Creates a GitHub release with the version tag
+
+#### Manual Release
+
+To manually release a new version:
+
+1. Update version in `package.json`
+2. Commit and push to main
+3. The GitHub Action will automatically publish to npm
+
+#### Setup for Maintainers
+
+To enable automatic releases, add an npm token to GitHub Secrets:
+
+1. Generate an npm token at https://www.npmjs.com/settings/YOUR_USERNAME/tokens
+2. Add it as `NPM_TOKEN` in repository Settings → Secrets and variables → Actions
+
 ## License
 
 MIT


### PR DESCRIPTION
## 概要
GitHub Actionsを使用した自動リリースCIを追加しました。

## 機能
- `package.json`のバージョンが更新されてmainブランチにプッシュされると自動的にリリース
- npm publishとGitHubリリースの作成を自動化
- バージョンタグの重複チェック機能

## ワークフローの動作
1. mainブランチへのプッシュまたは手動トリガー
2. package.jsonのバージョン変更を検知
3. そのバージョンのタグが存在しないことを確認
4. テスト実行
5. npm publish
6. GitHubリリース作成（v0.1.x形式のタグ付き）

## セットアップ
リポジトリのSettingsで`NPM_TOKEN`シークレットを追加してください：
1. https://www.npmjs.com/ でトークンを生成
2. Settings → Secrets and variables → Actions
3. `NPM_TOKEN`として追加

## 今後のリリースフロー
1. PRで`package.json`のバージョンを更新
2. PRをmainにマージ
3. 自動的にnpmへパブリッシュされます

## 関連Issue
自動リリースCIの要望に対応