### PR TITLE
feat: Auto-detect git repository root for session file discovery (v0.2.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccstats",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccstats",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccstats",
-  "version": "1.0.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccstats",
-      "version": "1.0.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -18,7 +18,7 @@
         "ccstats": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
+        "@types/node": "^20.19.11",
         "tsx": "^4.0.0",
         "typescript": "^5.0.0"
       }
@@ -472,9 +472,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
-      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccstats",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Claude Code session statistics tool",
   "main": "dist/index.js",
   "bin": {
@@ -21,7 +21,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^20.0.0",
+    "@types/node": "^20.19.11",
     "tsx": "^4.0.0",
     "typescript": "^5.0.0"
   },


### PR DESCRIPTION
## Summary
- 🚀 Automatic git repository root detection for finding Claude Code session files
- 🔧 New `--no-git-root` option to disable auto-detection when needed
- 📦 Version bump to 0.2.0

## Changes
This PR introduces automatic git repository root detection, allowing ccstats to work from any subdirectory within a git repository. Previously, users had to run ccstats from the exact directory where Claude Code was initiated.

### New Features
- **Auto-detection by default**: ccstats now automatically detects the git repository root using `git rev-parse --show-toplevel`
- **Works from any subdirectory**: You can now run ccstats from any subdirectory in your project
- **Fallback behavior**: If not in a git repository, ccstats falls back to using the current directory
- **Opt-out option**: Added `--no-git-root` flag to disable auto-detection when needed

### Technical Details
- Uses `child_process.execSync` to run `git rev-parse --show-toplevel`
- Gracefully handles non-git directories with fallback to current directory
- Debug mode shows which directory is being used for session file search

## Test Plan
- [x] Test from git repository root directory
- [x] Test from subdirectory with auto-detection
- [x] Test `--no-git-root` option to disable auto-detection
- [x] Test in non-git directory (fallback behavior)
- [x] Build successful with `npm run build`

## Release Notes
After merging this PR, you'll need to manually publish to npm:
```bash
npm publish
```

Note: No automated CI/CD workflow is currently configured for npm releases.

🤖 Generated with [Claude Code](https://claude.ai/code)